### PR TITLE
Fix error on lowdown-0.1.0

### DIFF
--- a/markdown-svnwiki.scm
+++ b/markdown-svnwiki.scm
@@ -122,7 +122,7 @@
     (verbatim . ,(lambda (_ attrs)
                    (list
 		    (map (lambda (s)
-			   (map (lambda (s) (list "    " s)) s))
+			   (map (lambda (s) (list "    " s)) (if (list? s) s (list s))))
 			 attrs)
 		    #\newline)))
     (code . ,(lambda (_ attrs)


### PR DESCRIPTION
I was getting a mysterious error message:

```
printf "##header\n    [procedure] (name)\n" | markdown-svnwiki

Error: (map) bad argument type - not a list: "[procedure] (name)\n"

        Call history:

        char-set-literals.scm:37: set-sharp-read-syntax!                <--
```

This is caused by the new lowdown version having made changed to its
internal sxml representation:

```
$ git checkout 0.0.9 && chicken-install -s >/dev/nullPrevious HEAD position was c7295c5... Release 0.1.0
HEAD is now at 5e69258... Release 0.0.9
$ csi -R comparse -R lowdown-lolevel -e '(pp (parse document "    [procedure] (foo)\n    fo"))
'((verbatim ("[procedure] (foo)\n" "fo\n")))
```

The new version of lowdown has normalized its internal SXML
representation to this:

```
$ git checkout 0.1.0 && chicken-install -s >/dev/null
Previous HEAD position was 5e69258... Release 0.0.9
HEAD is now at c7295c5... Release 0.1.0
$ csi -R comparse -R lowdown-lolevel -e '(pp (parse document "    [procedure] (foo)\n    fo"))'
((verbatim "[procedure] (foo)\n" "fo\n"))
```

This patch should make markdown-svnwiki work on both lowdown version.