### PR TITLE
Avoid error on empty input from port

### DIFF
--- a/markdown-svnwiki.scm
+++ b/markdown-svnwiki.scm
@@ -171,7 +171,8 @@
           (loop ((cdar processing) str)
                 (cdr processing)))))
   (let* ([input (if (port? input)
-                    (read-string #f input)
+                    (let ((s (read-string #f input)))
+                      (if (eof-object? s) "" s))
                     input)]
          [string (process (pre-processing) input)])
     (receive (refs sxml) (partition reference-element? (markdown->sxml* string))


### PR DESCRIPTION
In CHICKEN 5 `read-string` returns EOF when the input port is empty, leading to an error when `process` is called expecting a string argument. This change uses the empty string on EOF to preserve the old behaviour, and keeps the code backward-compatible with C4.

```
$ csi -R markdown-svnwiki -e '(markdown->svnwiki (current-input-port))' </dev/null

Error: (irregex-replace/all) not a string: #!eof
```