### PR TITLE
Strip leading spaces from preformatted text and type definitions

### DIFF
--- a/markdown-svnwiki.scm
+++ b/markdown-svnwiki.scm
@@ -56,7 +56,7 @@
   (cons (string->symbol name)
         (lambda (s)
           (irregex-replace/all
-           `(: "\n    [" ,name "]" (* whitespace) (submatch-named def (+ (~ #\newline))) eol)
+           `(: "\n [" ,name "]" (* whitespace) (submatch-named def (+ (~ #\newline))) eol)
            s
            (lambda (m)
              (string-append "\n<" name ">" (irregex-match-substring m 'def)
@@ -67,16 +67,15 @@
    `((code-blocks .
       ,(lambda (s) ; Convert [lang:xxx] verbatim blocks into <enscript> tags
          (irregex-replace/all
-          '(: "\n    [lang:" (submatch-named lang (+ alphanumeric)) "]\n"
-              (submatch-named body (+ bol "    " (* (~ #\newline)) #\newline)))
+          '(: "\n [lang:" (submatch-named lang (+ alphanumeric)) "]\n"
+              (submatch-named body (+ bol " " (* (~ #\newline)) #\newline)))
           s
           (lambda (m)
             (string-append "\n<enscript highlight=\""
                            (irregex-match-substring m 'lang)
                            "\">"
                            (irregex-replace/all
-                            "\n    " (irregex-match-substring m 'body) "\n")
-                           
+                            "\n " (irregex-match-substring m 'body) "\n")
                            "</enscript>\n")))))
      ,(definition "procedure")
      ,(definition "macro")
@@ -146,7 +145,7 @@
     (verbatim . ,(lambda (_ attrs)
                    (list
 		    (map (lambda (s)
-			   (map (lambda (s) (list "    " s)) (if (list? s) s (list s))))
+			   (map (lambda (s) (list " " s)) (if (list? s) s (list s))))
 			 attrs)
 		    #\newline)))
     (code . ,(lambda (_ attrs)

--- a/markdown-svnwiki.scm
+++ b/markdown-svnwiki.scm
@@ -56,7 +56,7 @@
   (cons (string->symbol name)
         (lambda (s)
           (irregex-replace/all
-           `(: "\n    [" ,name "]" (submatch-named def (+ (~ #\newline))) eol)
+           `(: "\n    [" ,name "]" (* whitespace) (submatch-named def (+ (~ #\newline))) eol)
            s
            (lambda (m)
              (string-append "\n<" name ">" (irregex-match-substring m 'def)


### PR DESCRIPTION
A couple of commits that remove unnecessary whitespace from generated wiki markup.

 1. Trims leading whitespace in type tags.
 2. Indents preformatted text by one space, rather than four.

For example, these:

```
<procedure> (foo a b c)</procedure>
```
```
    verbatim text indented by four spaces
```

Turn into these:

```
<procedure>(foo a b c)</procedure>
```
```
 verbatim text indented by one space
```

Commit messages provide details. Any questions, just let me know!