### PR TITLE
Handle Markdown's newlines

### DIFF
--- a/markdown-svnwiki.scm
+++ b/markdown-svnwiki.scm
@@ -126,7 +126,7 @@
                             '()))))
     (paragraph . ,(lambda (_ attrs)
                     `(,attrs #\newline #\newline)))
-    (br . ,(lambda _ (#\newline #\newline)))
+    (br . ,(lambda _ '(#\newline #\newline)))
     (explicit-link . ,(lambda (_ attrs)
                         (make-link attrs)))
     (reference-link . ,(lambda (_ attrs)

--- a/markdown-svnwiki.scm
+++ b/markdown-svnwiki.scm
@@ -126,6 +126,7 @@
                             '()))))
     (paragraph . ,(lambda (_ attrs)
                     `(,attrs #\newline #\newline)))
+    (br . ,(lambda _ (#\newline #\newline)))
     (explicit-link . ,(lambda (_ attrs)
                         (make-link attrs)))
     (reference-link . ,(lambda (_ attrs)


### PR DESCRIPTION
Markdown uses two spaces at end of line for a hard wrap.  
This isn't supported by svnwiki as far as I know (if it is then please change it to that) so for now just inserting a blank line here.